### PR TITLE
feat(metadata): updated expected values in tests

### DIFF
--- a/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2ColumnOrganizedStachTests.java
+++ b/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2ColumnOrganizedStachTests.java
@@ -63,7 +63,7 @@ public class V2ColumnOrganizedStachTests {
         StachExtensions stachExtension = stachExtensionBuilder.setPackage(input).build();
         List<TableData> tableDataList = stachExtension.convertToTable();
 
-        Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 19);
+        Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 18);
         Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "Single");
 
     }

--- a/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2ColumnOrganizedStachTests.java
+++ b/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2ColumnOrganizedStachTests.java
@@ -64,7 +64,7 @@ public class V2ColumnOrganizedStachTests {
         List<TableData> tableDataList = stachExtension.convertToTable();
 
         Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 18);
-        Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "Single");
+        Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "[\"Single\"]");
 
     }
 

--- a/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2RowOrganizedStachTests.java
+++ b/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2RowOrganizedStachTests.java
@@ -93,7 +93,7 @@ public class V2RowOrganizedStachTests {
         List<TableData> tableDataList = stachExtension.convertToTable();
 
         Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 18);
-        Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "Single");
+        Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "[\"Single\"]");
 
     }
 }

--- a/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2RowOrganizedStachTests.java
+++ b/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2RowOrganizedStachTests.java
@@ -92,7 +92,7 @@ public class V2RowOrganizedStachTests {
         StachExtensions stachExtension = stachExtensionBuilder.setPackage(input).build();
         List<TableData> tableDataList = stachExtension.convertToTable();
 
-        Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 19);
+        Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 18);
         Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "Single");
 
     }

--- a/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2SimplifiedRowOrganizedStachTests.java
+++ b/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2SimplifiedRowOrganizedStachTests.java
@@ -66,7 +66,7 @@ public class V2SimplifiedRowOrganizedStachTests {
         List<TableData> tableDataList = stachExtension.convertToTable();
 
         Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 18);
-        Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "Single");
+        Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "[\"Single\"]");
 
     }
 

--- a/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2SimplifiedRowOrganizedStachTests.java
+++ b/java/src/test/java/com/factset/protobuf/stach/extensions/tests/V2SimplifiedRowOrganizedStachTests.java
@@ -65,7 +65,7 @@ public class V2SimplifiedRowOrganizedStachTests {
         StachExtensions stachExtension = stachExtensionBuilder.setPackage(input).build();
         List<TableData> tableDataList = stachExtension.convertToTable();
 
-        Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 19);
+        Assert.assertEquals(tableDataList.get(0).getMetadata().keySet().toArray().length, 18);
         Assert.assertEquals(tableDataList.get(0).getMetadata().get("Report Frequency"), "Single");
 
     }


### PR DESCRIPTION
The tests for metadata were failing because the expected values needed to be updated to reflect the new length and format of metadata. I changed the expected length from 19 to 18 and added brackets around the values.