### PR TITLE
feat(metadata): implemented metadata for Python

### DIFF
--- a/python/.vscode/settings.json
+++ b/python/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true
+}

--- a/python/README.md
+++ b/python/README.md
@@ -7,11 +7,18 @@ For manual install and testing from the source code follow the below instruction
 
 ## Installation
 
-Navigate into the "src" folder and run the below commands
-
 ``` python
+cd src
 python setup.py sdist
-pip install .
+```
+Copy and paste `fds.protobuf.stach.extensions-1.0.1.tar` from `src/dist` to `tests`
+``` python
+cd ../tests
+```
+Create a virtual environment
+``` python
+pip install -r requirements.txt
+pip install fds.protobuf.stach.extensions-1.0.1.tar
 ```
 
 ## Testing
@@ -22,3 +29,6 @@ Navigate to the "tests" folder and run the below command
 ```python
 python -m unittest discover -p "test_*.py"
 ```
+#### Or
+
+Follow [these](https://code.visualstudio.com/docs/python/testing#_configure-tests) steps to run tests within VSCode

--- a/python/src/fds/protobuf/stach/extensions/v1/ColumnOrganizedStachExtension.py
+++ b/python/src/fds/protobuf/stach/extensions/v1/ColumnOrganizedStachExtension.py
@@ -17,6 +17,12 @@ class ColumnOrganizedStachExtension(IStachExtension):
             tables.append(ColumnOrganizedStachExtension.__generate_table(self.package, primary_table_id))
         return tables
 
+    def get_metadata(self):
+        metadata = list()
+        for primary_table_id in self.package.primary_table_ids:
+            metadata.append(self.__generate_metadata(self.package, primary_table_id))
+        return metadata
+
     @staticmethod
     def __generate_table(package_response, primary_table_id):
         """
@@ -70,3 +76,24 @@ class ColumnOrganizedStachExtension(IStachExtension):
 
         else:
             ValueError("Response data passed should be of package type.")
+
+    @staticmethod
+    def __generate_metadata(package_response, primary_table_id):
+        """
+        The purpose of this function is to generate the metadata for the provided stach data through the package.
+
+        :param package_response: Stach Data which is represented as a Package object.
+        :param primary_table_id: Refers to the id for a particular table inside a package.
+        :return: Returns the generated metadata from the package provided.
+        """
+        primary_table = package_response.tables[primary_table_id]
+        metadata = {}
+
+        for location in primary_table.data.metadata.locations.table:
+            name = primary_table.data.metadata.items[location].name
+
+            stringval = primary_table.data.metadata.items[location].string_value
+            values = stringval.split("|")
+            
+            metadata[name] = values
+        return metadata

--- a/python/src/fds/protobuf/stach/extensions/v2/ColumnOrganizedStachExtension.py
+++ b/python/src/fds/protobuf/stach/extensions/v2/ColumnOrganizedStachExtension.py
@@ -19,6 +19,12 @@ class ColumnOrganizedStachExtension(IStachExtension):
             tables.append(self.__generate_table(self.package, primary_table_id))
         return tables
 
+    def get_metadata(self):
+        metadata = list()
+        for primary_table_id in self.package.primary_table_ids:
+            metadata.append(self.__generate_metadata(self.package, primary_table_id))
+        return metadata
+
     @staticmethod
     def __generate_table(package_response, primary_table_id):
         """
@@ -76,3 +82,23 @@ class ColumnOrganizedStachExtension(IStachExtension):
             else:
                 data_frame = pd.DataFrame(data=data, columns=headers[0])
             return data_frame
+
+    @staticmethod
+    def __generate_metadata(package_response, primary_table_id):
+        """
+        The purpose of this function is to generate the metadata for the provided stach data through the package.
+
+        :param package_response: Stach Data which is represented as a Package object.
+        :param primary_table_id: Refers to the id for a particular table inside a package.
+        :return: Returns the generated metadata from the package provided.
+        """
+        primary_table = package_response.tables[primary_table_id]
+        metadata = {}
+
+        for location in primary_table.data.metadata.locations.table:
+            if (len(primary_table.data.metadata.items[location].value.list_value.values) > 0):
+                values = list()
+                for value in primary_table.data.metadata.items[location].value.list_value.values:
+                    values.append(value)
+                metadata[location] = values
+        return metadata

--- a/python/src/fds/protobuf/stach/extensions/v2/RowOrganizedStachExtension.py
+++ b/python/src/fds/protobuf/stach/extensions/v2/RowOrganizedStachExtension.py
@@ -20,6 +20,12 @@ class RowOrganizedStachExtension(IStachExtension):
             tables.append(RowOrganizedStachExtension.__generate_table(self.package.tables[tableId]))
         return tables
 
+    def get_metadata(self):
+        metadata = list()
+        for tableId in self.package.tables:
+            metadata.append(RowOrganizedStachExtension.__generate_metadata(self.package.tables[tableId]))
+        return metadata
+
     @staticmethod
     def __generate_table(table):
         """
@@ -110,3 +116,22 @@ class RowOrganizedStachExtension(IStachExtension):
             data_frame = data_frame.replace({np.nan: None})
 
             return data_frame
+
+    @staticmethod
+    def __generate_metadata(table):
+        """
+        The purpose of this function is to generate the metadata for the provided stach data through the package.
+
+        :param table: A particular table inside a package.
+        :return: Returns the generated metadata from the package provided.
+        """
+        metadata = {}
+
+        for metadataItem in table.data.table_metadata:
+            values = list()
+            for value in table.data.table_metadata[metadataItem].value.list_value.values:
+                values.append(value)
+
+            metadata[metadataItem] = values
+
+        return metadata

--- a/python/tests/.vscode/settings.json
+++ b/python/tests/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true
+}

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,0 +1,17 @@
+astroid==2.7.3
+colorama==0.4.4
+fds.protobuf.stach==1.0.0
+fds.protobuf.stach.v2==1.0.2
+isort==5.9.3
+lazy-object-proxy==1.6.0
+mccabe==0.6.1
+numpy==1.21.2
+pandas==1.3.2
+platformdirs==2.3.0
+protobuf==3.17.3
+pylint==2.10.2
+python-dateutil==2.8.2
+pytz==2021.1
+six==1.16.0
+toml==0.10.2
+wrapt==1.12.1

--- a/python/tests/test_v1_column.py
+++ b/python/tests/test_v1_column.py
@@ -22,6 +22,17 @@ class V1StachTests(unittest.TestCase):
             self.assertEqual(headerColumns, tables[0].columns.values.tolist())
             self.assertEqual(firstRow, tables[0].iloc[0].values.tolist())
 
+    def test_stachv1_metadata(self):
+        file = os.path.join(ROOT_DIR, "resources", "V1ColumnStachData.json")
+        with open(file) as f:
+            data = json.load(f)
+            stachBuilder = StachExtensionFactory.get_column_organized_builder(StachVersion.V1)
+            stachExtension = stachBuilder.set_package(data).build()
+            metadata = stachExtension.get_metadata()
+
+            self.assertEqual(18, len(metadata[0]))
+            self.assertEqual("Single", metadata[0]["Report Frequency"][0])
+            self.assertEqual("Industry - Beginning of Period", metadata[0]["Grouping Frequency"][1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_v2_column.py
+++ b/python/tests/test_v2_column.py
@@ -22,6 +22,17 @@ class V2StachTests(unittest.TestCase):
             self.assertEqual(headerColumns, tables[0].columns.values.tolist())
             self.assertEqual(firstRow, tables[0].iloc[0].values.tolist())
 
+    def test_stachv2_metadata(self):
+        file = os.path.join(ROOT_DIR, "resources", "V2ColumnStachData.json")
+        with open(file) as f:
+            data = json.load(f)
+            stachBuilder = StachExtensionFactory.get_column_organized_builder(StachVersion.V2)
+            stachExtension = stachBuilder.set_package(data).build()
+            metadata = stachExtension.get_metadata()
+
+            self.assertEqual(18, len(metadata[0]))
+            self.assertEqual("Single", metadata[0]["Report Frequency"][0].string_value)
+            self.assertEqual("Industry - Beginning of Period", metadata[0]["Grouping Frequency"][1].string_value)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_v2_row.py
+++ b/python/tests/test_v2_row.py
@@ -40,9 +40,8 @@ class V2StachTests(unittest.TestCase):
         file = os.path.join(ROOT_DIR, "resources", "V2RowStachData.json")
         with open(file) as f:
             data = json.load(f)
-            table = data['tables']['3805a4c8-5493-4e63-9d71-c553d20f266b']
             stachBuilder = StachExtensionFactory.get_row_organized_builder(StachVersion.V2)
-            stachExtension = stachBuilder.add_table("id1", table).build()
+            stachExtension = stachBuilder.set_package(data).build()
             metadata = stachExtension.get_metadata()
 
             self.assertEqual(18, len(metadata[0]))

--- a/python/tests/test_v2_row.py
+++ b/python/tests/test_v2_row.py
@@ -36,6 +36,18 @@ class V2StachTests(unittest.TestCase):
             self.assertEqual(headerColumns, tables[0].columns.values.tolist())
             self.assertEqual(firstRow, tables[0].iloc[0].values.tolist())
 
+    def test_stachv2_metadata(self):
+        file = os.path.join(ROOT_DIR, "resources", "V2RowStachData.json")
+        with open(file) as f:
+            data = json.load(f)
+            table = data['tables']['3805a4c8-5493-4e63-9d71-c553d20f266b']
+            stachBuilder = StachExtensionFactory.get_row_organized_builder(StachVersion.V2)
+            stachExtension = stachBuilder.add_table("id1", table).build()
+            metadata = stachExtension.get_metadata()
+
+            self.assertEqual(18, len(metadata[0]))
+            self.assertEqual("Single", metadata[0]["Report Frequency"][0].string_value)
+            self.assertEqual("Industry - FactSet - Beginning of Period", metadata[0]["Grouping Frequency"][1].string_value)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_v2_simplifiedrow.py
+++ b/python/tests/test_v2_simplifiedrow.py
@@ -22,6 +22,17 @@ class V2StachTests(unittest.TestCase):
             self.assertEqual(headerColumns, tables[0].columns.values.tolist())
             self.assertEqual(firstRow, tables[0].iloc[0].values.tolist())
 
+    def test_stachv2_metadata(self):
+        file = os.path.join(ROOT_DIR, "resources", "V2SimplifiedRowStachData.json")
+        with open(file) as f:
+            data = json.load(f)
+            stachBuilder = StachExtensionFactory.get_row_organized_builder(StachVersion.V2)
+            stachExtension = stachBuilder.set_package(data).build()
+            metadata = stachExtension.get_metadata()
+
+            self.assertEqual(18, len(metadata[0]))
+            self.assertEqual("Single", metadata[0]["Report Frequency"][0].string_value)
+            self.assertEqual("Industry - Beginning of Period", metadata[0]["Grouping Frequency"][1].string_value)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
These changes implement `get_metadata()` and `_generate_metadata()` in V1 and V2, which generates and returns a metadata dictionary that maps strings to values.

https://bpm.factset.com/browse/AAPI-2244