### PR TITLE
feat(simplifiedRow): adding new methods in dotnet

### DIFF
--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions.Tests/StachV2SimplifiedRowTests.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions.Tests/StachV2SimplifiedRowTests.cs
@@ -67,23 +67,27 @@ namespace FactSet.Protobuf.Stach.Extensions.Tests
         {
             var firstItem = new Dictionary<string, dynamic>(){{"total0", "Total"}, {"group1", null}, {"group2", null}, {"Port.+Weight", 100.0},
                 {"Bench.+Weight", null}, {"Difference", 100.0}};
+            var keysValue = new List<string>() { "total0 | group1 | group2", "Total", "Communications", "Communications | Wireless Telecommunications",
+                "Finance | Regional Banks | State Bank of India", "Utilities | Electric Utilities | Power Grid Corporation of India Limited"};
             
             var simplifiedRowStachBuilder = StachExtensionFactory.GetSimplifiedRowOrganizedStachBuilder();
             var stachExtension = simplifiedRowStachBuilder.SetPackage(input).Build();
-            var dynamicObject = stachExtension.ConvertToDynamicObject();
-            var transposedDynamicObject = stachExtension.ConvertToTransposedDynamicObject();
+            var dynamicObject = stachExtension.ConvertToDynamicObjects();
+            var transposedDynamicObject = stachExtension.ConvertToTransposedDynamicObjects();
             var table = stachExtension.ConvertToTable();
 
             Assert.IsTrue(dynamicObject.Count == 61, "There is an incorrect amount of items in the dynamic object");
-            Assert.IsTrue(((IDictionary<string,dynamic>)transposedDynamicObject.First()).Count == 62, "There is an incorrect amount of items in the transposed dynamic object");
+            Assert.IsTrue(((IDictionary<string, dynamic>)transposedDynamicObject.First()).Count == 62, "There is an incorrect amount of items in the transposed dynamic object");
             Assert.IsTrue(table[0].Rows.Count == 62);
             Assert.IsTrue(transposedDynamicObject.Count == 3);
-
-            var i = 0;
-            foreach (var pair in (IDictionary<string, object>)dynamicObject[0])
+            foreach (var key in keysValue)
             {
-                Assert.IsTrue(pair.Key.Equals(firstItem.Keys.ToArray()[i]));
-                i++;
+                Assert.IsTrue(((IDictionary<string, dynamic>)transposedDynamicObject.First()).ContainsKey(key), $"{key} is missing from the transposed object's key list");
+            }
+
+            foreach (var item in firstItem)
+            {
+                Assert.IsTrue(((IDictionary<string, dynamic>)dynamicObject.First()).ContainsKey(item.Key), $"{item.Key} is missing from the dynamic object's key list");
             }
         }
     }

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions.Tests/StachV2SimplifiedRowTests.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions.Tests/StachV2SimplifiedRowTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Dynamic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FactSet.Protobuf.Stach.Extensions.V2;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -59,6 +61,27 @@ namespace FactSet.Protobuf.Stach.Extensions.Tests
 
             Assert.IsTrue(table[0].RawMetadata.Count == 1, "There is an incorrect amount of RawMetadata items");
             Assert.AreEqual("78647885fa4f4594b775a1431e62090c:", StachUtilities.ValueToString(table[0].RawMetadata["CalculationId"][0]));
+        }
+
+        [TestMethod]
+        public void TestMethod3()
+        {
+            var firstItem = new Dictionary<dynamic, dynamic>(){{"total0", "Total"}, {"group1", null}, {"group2", null}, {"Port.+Weight", 100.0},
+                {"Bench.+Weight", null}, {"Difference", 100.0}};
+            
+            var simplifiedRowStachBuilder = StachExtensionFactory.GetSimplifiedRowOrganizedStachBuilder();
+            var stachExtension = simplifiedRowStachBuilder.SetPackage(input).Build();
+            var dynamicObject = stachExtension.ConvertToDynamicObject();
+            var transposedDynamicObject = stachExtension.ConvertToTransposedDynamicObject();
+            var table = stachExtension.ConvertToTable();
+            
+            Assert.IsTrue(dynamicObject.Count == 61, "There is an incorrect amount of items in the dynamic object");
+            Assert.IsTrue(transposedDynamicObject.First().Count == 62, "There is an incorrect amount of items in the transposed dynamic object");
+            Assert.IsTrue(table[0].Rows.Count == 62);
+            Assert.IsTrue(transposedDynamicObject.Count == 3);
+            
+            CollectionAssert.AreEqual(firstItem, dynamicObject[0]);
+            
         }
     }
 }

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions.Tests/StachV2SimplifiedRowTests.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions.Tests/StachV2SimplifiedRowTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -66,7 +65,7 @@ namespace FactSet.Protobuf.Stach.Extensions.Tests
         [TestMethod]
         public void TestMethod3()
         {
-            var firstItem = new Dictionary<dynamic, dynamic>(){{"total0", "Total"}, {"group1", null}, {"group2", null}, {"Port.+Weight", 100.0},
+            var firstItem = new Dictionary<string, dynamic>(){{"total0", "Total"}, {"group1", null}, {"group2", null}, {"Port.+Weight", 100.0},
                 {"Bench.+Weight", null}, {"Difference", 100.0}};
             
             var simplifiedRowStachBuilder = StachExtensionFactory.GetSimplifiedRowOrganizedStachBuilder();
@@ -74,14 +73,18 @@ namespace FactSet.Protobuf.Stach.Extensions.Tests
             var dynamicObject = stachExtension.ConvertToDynamicObject();
             var transposedDynamicObject = stachExtension.ConvertToTransposedDynamicObject();
             var table = stachExtension.ConvertToTable();
-            
+
             Assert.IsTrue(dynamicObject.Count == 61, "There is an incorrect amount of items in the dynamic object");
-            Assert.IsTrue(transposedDynamicObject.First().Count == 62, "There is an incorrect amount of items in the transposed dynamic object");
+            Assert.IsTrue(((IDictionary<string,dynamic>)transposedDynamicObject.First()).Count == 62, "There is an incorrect amount of items in the transposed dynamic object");
             Assert.IsTrue(table[0].Rows.Count == 62);
             Assert.IsTrue(transposedDynamicObject.Count == 3);
-            
-            CollectionAssert.AreEqual(firstItem, dynamicObject[0]);
-            
+
+            var i = 0;
+            foreach (var pair in (IDictionary<string, object>)dynamicObject[0])
+            {
+                Assert.IsTrue(pair.Key.Equals(firstItem.Keys.ToArray()[i]));
+                i++;
+            }
         }
     }
 }

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/FactSet.Protobuf.Stach.Extensions.csproj
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/FactSet.Protobuf.Stach.Extensions.csproj
@@ -10,7 +10,7 @@
         <Authors>FactSet Research Systems, Inc.</Authors>
         <Company>FactSet Research Systems, Inc</Company>
         <Product>FactSet.Protobuf.Stach.Extensions</Product>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/factset/stach-extensions.git</RepositoryUrl>
         <PackageTags>STACH;Protobuf;FactSet;FDS;Analytics;Analytics API</PackageTags>

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowOrganizedStachBuilder.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowOrganizedStachBuilder.cs
@@ -1,0 +1,65 @@
+﻿using FactSet.Protobuf.Stach.V2;
+
+namespace FactSet.Protobuf.Stach.Extensions
+{
+    public interface ISimplifiedRowOrganizedStachBuilder
+    {
+        /// <summary>
+        /// Builds and returns the Simplified Row Organized Stach Extension instance.
+        /// </summary>
+        /// <returns>SimplifiedRowOrganizedStachExtension instance</returns>
+        ISimplifiedRowStachExtension Build();
+
+        /// <summary>
+        /// Sets the RowOrganizedPackage.
+        /// </summary>
+        /// <param name="package">RowOrganizedPackage object</param>
+        /// <returns>builder instance</returns>
+        ISimplifiedRowOrganizedStachBuilder SetPackage(RowOrganizedPackage package);
+
+        /// <summary>
+        /// Sets the RowOrganizedPackage by parsing the raw object input.
+        /// </summary>
+        /// <param name="package">RowOrganizedPackage object</param>
+        /// <returns>builder instance</returns>
+        ISimplifiedRowOrganizedStachBuilder SetPackage(object package);
+
+        /// <summary>
+        /// Sets the RowOrganizedPackage by parsing the string input.
+        /// </summary>
+        /// <param name="package">string form of RowOrganizedPackage object</param>
+        /// <returns>builder instance</returns>
+        ISimplifiedRowOrganizedStachBuilder SetPackage(string package);
+
+        /// <summary>
+        /// Add the SimplifiedRowOrganized Table to the package in the builder.
+        /// </summary>
+        /// <param name="tableId">id of the table.</param>
+        /// <param name="simplifiedRowOrganizedTable">SimplifiedRowOrganized Table</param>
+        /// <returns>builder instance</returns>
+        ISimplifiedRowOrganizedStachBuilder AddTable(string tableId, RowOrganizedPackage.Types.Table simplifiedRowOrganizedTable);
+
+        /// <summary>
+        /// Add the SimplifiedRowOrganized Table to the package in the builder.
+        /// </summary>
+        /// <param name="tableId">id of the table.</param>
+        /// <param name="simplifiedRowOrganizedTableString">SimplifiedRowOrganized Table in string format</param>
+        /// <returns>builder instance</returns>
+        ISimplifiedRowOrganizedStachBuilder AddTable(string tableId, string simplifiedRowOrganizedTableString);
+
+        /// <summary>
+        /// Add the SimplifiedRowOrganized Table to the package in the builder.
+        /// </summary>
+        /// <param name="tableId">id of the table.</param>
+        /// <param name="simplifiedRowOrganizedTableObject">SimplifiedRowOrganized Table object</param>
+        /// <returns>builder instance</returns>
+        ISimplifiedRowOrganizedStachBuilder AddTable(string tableId, object simplifiedRowOrganizedTableObject);
+
+        /// <summary>
+        /// Get the RowOrganizedPackage set for the builder.
+        /// </summary>
+        /// <returns>RowOrganizedPackage</returns>
+        RowOrganizedPackage GetPackage();
+
+    }
+}

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowOrganizedStachBuilder.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowOrganizedStachBuilder.cs
@@ -32,7 +32,7 @@ namespace FactSet.Protobuf.Stach.Extensions
         ISimplifiedRowOrganizedStachBuilder SetPackage(string package);
 
         /// <summary>
-        /// Add the SimplifiedRowOrganized Table to the package in the builder.
+        /// Add the Simplified Row Organized format's Table to the package in the builder.
         /// </summary>
         /// <param name="tableId">id of the table.</param>
         /// <param name="simplifiedRowOrganizedTable">SimplifiedRowOrganized Table</param>
@@ -40,7 +40,7 @@ namespace FactSet.Protobuf.Stach.Extensions
         ISimplifiedRowOrganizedStachBuilder AddTable(string tableId, RowOrganizedPackage.Types.Table simplifiedRowOrganizedTable);
 
         /// <summary>
-        /// Add the SimplifiedRowOrganized Table to the package in the builder.
+        /// Add the Simplified Row Organized format's Table to the package in the builder.
         /// </summary>
         /// <param name="tableId">id of the table.</param>
         /// <param name="simplifiedRowOrganizedTableString">SimplifiedRowOrganized Table in string format</param>
@@ -48,7 +48,7 @@ namespace FactSet.Protobuf.Stach.Extensions
         ISimplifiedRowOrganizedStachBuilder AddTable(string tableId, string simplifiedRowOrganizedTableString);
 
         /// <summary>
-        /// Add the SimplifiedRowOrganized Table to the package in the builder.
+        /// Add the Simplified Row Organized format's Table to the package in the builder.
         /// </summary>
         /// <param name="tableId">id of the table.</param>
         /// <param name="simplifiedRowOrganizedTableObject">SimplifiedRowOrganized Table object</param>

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowStachExtension.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowStachExtension.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace FactSet.Protobuf.Stach.Extensions
+{
+    public interface ISimplifiedRowStachExtension : IStachExtension
+    {
+        List<dynamic> ConvertToDynamicObject();
+
+        List<dynamic> ConvertToTransposedDynamicObject();
+
+        string GetStringifiedCsv(List<dynamic> outputObject);
+    }
+}

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowStachExtension.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowStachExtension.cs
@@ -4,8 +4,17 @@ namespace FactSet.Protobuf.Stach.Extensions
 {
     public interface ISimplifiedRowStachExtension : IStachExtension
     {
-        List<dynamic> ConvertToDynamicObject();
-
-        List<dynamic> ConvertToTransposedDynamicObject();
+        /// <summary>
+        /// Converts the RowOrganizedPackage of SimplifiedRow format to a list of dynamic objects.
+        /// </summary>
+        /// <returns>List of dynamic objects</returns>
+        List<dynamic> ConvertToDynamicObjects();
+        
+        /// <summary>
+        /// Converts the RowOrganizedPackage of SimplifiedRow format to a list of transposed dynamic objects.
+        /// It concatenates groupings with a delimiter of pipe
+        /// </summary>
+        /// <returns>List of transposed dynamic objects</returns>
+        List<dynamic> ConvertToTransposedDynamicObjects();
     }
 }

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowStachExtension.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/ISimplifiedRowStachExtension.cs
@@ -7,7 +7,5 @@ namespace FactSet.Protobuf.Stach.Extensions
         List<dynamic> ConvertToDynamicObject();
 
         List<dynamic> ConvertToTransposedDynamicObject();
-
-        string GetStringifiedCsv(List<dynamic> outputObject);
     }
 }

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/StachExtensionFactory.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/StachExtensionFactory.cs
@@ -34,6 +34,15 @@ namespace FactSet.Protobuf.Stach.Extensions
         {
             return new RowOrganizedStachBuilder();
         }
+
+        /// <summary>
+        /// Get the SimplifiedRowOrganizedStachBuilder instance.
+        /// </summary>
+        /// <returns>SimplifiedRowOrganizedStachBuilder</returns>
+        public static ISimplifiedRowOrganizedStachBuilder GetSimplifiedRowOrganizedStachBuilder()
+        {
+            return new SimplifiedRowOrganizedStachBuilder();
+        }
     }
 
 }

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/SimplifiedRowOrganizedStachBuilder.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/SimplifiedRowOrganizedStachBuilder.cs
@@ -1,0 +1,72 @@
+﻿using FactSet.Protobuf.Stach.V2;
+using Google.Protobuf;
+using Newtonsoft.Json;
+
+namespace FactSet.Protobuf.Stach.Extensions.V2
+{
+    public class SimplifiedRowOrganizedStachBuilder : ISimplifiedRowOrganizedStachBuilder
+    {
+        private RowOrganizedPackage package;
+
+        public ISimplifiedRowOrganizedStachBuilder SetPackage(RowOrganizedPackage package)
+        {
+            this.package = package;
+            return this;
+        }
+
+        public ISimplifiedRowOrganizedStachBuilder SetPackage(string package)
+        {
+            var jpSettings = JsonParser.Settings.Default;
+            var jp = new JsonParser(jpSettings.WithIgnoreUnknownFields(true));
+            this.package = jp.Parse<RowOrganizedPackage>(package);
+            return this;
+        }
+
+        public ISimplifiedRowOrganizedStachBuilder SetPackage(object package)
+        {
+            var pkgString = JsonConvert.SerializeObject(package);
+            return SetPackage(pkgString);
+        }
+
+        public ISimplifiedRowOrganizedStachBuilder AddTable(string tableId, RowOrganizedPackage.Types.Table simplifiedRowOrganizedTable)
+        {
+            if (package == null)
+            {
+                package = new RowOrganizedPackage();
+            }
+
+            package.Tables.Add(tableId, simplifiedRowOrganizedTable);
+            return this;
+        }
+
+        public ISimplifiedRowOrganizedStachBuilder AddTable(string tableId, string simplifiedRowOrganizedTableString)
+        {
+            var jpSettings = JsonParser.Settings.Default;
+            var jp = new JsonParser(jpSettings.WithIgnoreUnknownFields(true));
+            var table = jp.Parse<RowOrganizedPackage.Types.Table>(simplifiedRowOrganizedTableString);
+            if (package == null)
+            {
+                package = new RowOrganizedPackage();
+            }
+
+            package.Tables.Add(tableId, table);
+            return this;
+        }
+
+        public ISimplifiedRowOrganizedStachBuilder AddTable(string tableId, object simplifiedRowOrganizedTableObject)
+        {
+            var tableString = JsonConvert.SerializeObject(simplifiedRowOrganizedTableObject);
+            return AddTable(tableId, tableString);
+        }
+
+        public RowOrganizedPackage GetPackage()
+        {
+            return package;
+        }
+
+        public ISimplifiedRowStachExtension Build()
+        {
+            return new SimplifiedRowOrganizedStachExtension(package);
+        }
+    }
+}

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/SimplifiedRowOrganizedStachExtension.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/SimplifiedRowOrganizedStachExtension.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FactSet.Protobuf.Stach.V2;
+
+namespace FactSet.Protobuf.Stach.Extensions.V2
+{
+    public class SimplifiedRowOrganizedStachExtension : RowOrganizedStachExtension, ISimplifiedRowStachExtension
+    {
+        private RowOrganizedPackage pkg;
+        
+        public SimplifiedRowOrganizedStachExtension(RowOrganizedPackage pkg) : base(pkg)
+        {
+            this.pkg = pkg;
+        }
+        
+        public List<dynamic> ConvertToDynamicObject()
+        {
+            var output = new List<dynamic>();
+            
+            foreach (var table in pkg.Tables.Values)
+            {
+                var headerRow = new List<dynamic>();
+                foreach (var columnDefinition in table.Definition.Columns)
+                {
+                    var description = string.IsNullOrWhiteSpace(columnDefinition.Description)
+                        ? columnDefinition.Name
+                        : columnDefinition.Description;
+                    headerRow.Add(description);
+                }
+
+                foreach (var dataRow in table.Data.Rows)
+                {
+                    dynamic data = new Dictionary<dynamic, dynamic>();
+                    for (var i = 0; i < dataRow.Values.Fields.Count; i++)
+                    {
+                        data.Add(headerRow[i], StachUtilities.ValueToObject(dataRow.Values.Fields["col_"+i]));
+                    }
+                    output.Add(data);
+                }
+            }
+
+            return output;
+        }
+
+        public List<dynamic> ConvertToTransposedDynamicObject()
+        {
+            var transposedOutput = new List<dynamic>();
+
+            foreach (var table in pkg.Tables.Values)
+            {
+                var headerKeys = new List<dynamic>();
+                
+                string key = null;
+                var dimensionColumnIds = new List<string>();
+                if (table.Definition.Columns.Count(c => c.IsDimension) == 0)
+                    table.Definition.Columns.First().IsDimension = true;
+                
+                foreach (var column in table.Definition.Columns)
+                {
+                    if (!column.IsDimension) continue;
+                    key +=  (column.Description?? column.Name) + " | ";
+                    dimensionColumnIds.Add(column.Id);
+                }
+                headerKeys.Add(key?.Remove(key.LastIndexOf(" | ", StringComparison.OrdinalIgnoreCase)));
+                
+                foreach (var row in table.Data.Rows)
+                {
+                    string keyValue = null;
+                    foreach (var id in dimensionColumnIds)
+                    {
+                        if (StachUtilities.ValueToString(row.Values.Fields[id]) == null) continue;
+                        keyValue += StachUtilities.ValueToString(row.Values.Fields[id]) + " | ";
+                    }
+                    headerKeys.Add(keyValue?.Remove(keyValue.LastIndexOf(" | ", StringComparison.OrdinalIgnoreCase)));
+                }
+                
+                foreach (var column in table.Definition.Columns)
+                {
+                    if (dimensionColumnIds.Contains(column.Id)) continue;
+                    
+                    var data = new Dictionary<string, dynamic>();
+                    data.Add(headerKeys[0], column.Description ?? column.Name);
+                    int j = 1;
+                    for (var i = 0; i < headerKeys.Count - 1; i++)
+                    {
+                        if (data.ContainsKey(headerKeys[i + 1]))
+                        {
+                            headerKeys[i + 1] += "_"+j;
+                            j++;
+                        }
+                        data.Add(headerKeys[i+1], StachUtilities.ValueToObject(table.Data.Rows[i].Values.Fields[column.Id]));
+                    }
+                    
+                    transposedOutput.Add(data);
+                }
+                
+            }
+            
+            return transposedOutput;
+        }
+
+        public string GetStringifiedCsv(List<dynamic> output)
+        {
+            string csv = null;
+            foreach (var pair in output.First())
+            {
+                csv += pair.Key.ToString() + ",";
+            }
+
+            csv += "\n";
+            foreach (var pair in output)
+            {
+                foreach (var item in pair)
+                {
+                    csv += item.Value?.ToString() + ",";
+                }
+
+                csv += "\n";
+            }
+
+            return csv;
+        }
+    }
+}

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/SimplifiedRowOrganizedStachExtension.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/SimplifiedRowOrganizedStachExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using FactSet.Protobuf.Stach.V2;
 
@@ -31,7 +32,7 @@ namespace FactSet.Protobuf.Stach.Extensions.V2
 
                 foreach (var dataRow in table.Data.Rows)
                 {
-                    dynamic data = new Dictionary<dynamic, dynamic>();
+                    var data = new ExpandoObject() as IDictionary<string, dynamic>;
                     for (var i = 0; i < dataRow.Values.Fields.Count; i++)
                     {
                         data.Add(headerRow[i], StachUtilities.ValueToObject(dataRow.Values.Fields["col_"+i]));
@@ -79,7 +80,7 @@ namespace FactSet.Protobuf.Stach.Extensions.V2
                 {
                     if (dimensionColumnIds.Contains(column.Id)) continue;
                     
-                    var data = new Dictionary<string, dynamic>();
+                    var data = new ExpandoObject() as IDictionary<string, dynamic>;
                     data.Add(headerKeys[0], column.Description ?? column.Name);
                     int j = 1;
                     for (var i = 0; i < headerKeys.Count - 1; i++)
@@ -98,28 +99,6 @@ namespace FactSet.Protobuf.Stach.Extensions.V2
             }
             
             return transposedOutput;
-        }
-
-        public string GetStringifiedCsv(List<dynamic> output)
-        {
-            string csv = null;
-            foreach (var pair in output.First())
-            {
-                csv += pair.Key.ToString() + ",";
-            }
-
-            csv += "\n";
-            foreach (var pair in output)
-            {
-                foreach (var item in pair)
-                {
-                    csv += item.Value?.ToString() + ",";
-                }
-
-                csv += "\n";
-            }
-
-            return csv;
         }
     }
 }

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/StachUtilities.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/StachUtilities.cs
@@ -34,6 +34,32 @@ namespace FactSet.Protobuf.Stach.Extensions.V2
             }
         }
 
+        public static object ValueToObject(Value value)
+        {
+            switch (value.KindCase)
+            {
+                case Value.KindOneofCase.BoolValue:
+                    return value.BoolValue;
+                
+                case Value.KindOneofCase.ListValue:
+                    return value.ListValue.ToString();
+                
+                case Value.KindOneofCase.NumberValue:
+                    return value.NumberValue;
+                
+                case Value.KindOneofCase.StringValue:
+                    return value.StringValue;
+                
+                case Value.KindOneofCase.StructValue:
+                    return JsonFormatter.Default.Format(value.StructValue);
+                
+                case Value.KindOneofCase.NullValue:
+                case Value.KindOneofCase.None:
+                default:
+                    return null;
+            }
+        }
+
         /// <summary>
         /// Checks if values needs to be added at the given row and given position based on rowspan information. If values needs to be added,
         /// builds the list of values to be added at the position and returns it.

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/StachUtilities.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/StachUtilities.cs
@@ -40,11 +40,11 @@ namespace FactSet.Protobuf.Stach.Extensions.V2
         }
 
         /// <summary>
-        /// Returns the actual value object instead of the Protobuf Value object.
+        /// Returns the underlying raw object from the protobuf Value object.
         /// For Lists and Struct, we return the stringified values.
         /// </summary>
         /// <param name="value"></param>
-        /// <returns>Actual value object</returns>
+        /// <returns>Raw object value</returns>
         public static object ValueToObject(Value value)
         {
             switch (value.KindCase)

--- a/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/StachUtilities.cs
+++ b/dotnet/StachExtensions/FactSet.Protobuf.Stach.Extensions/V2/StachUtilities.cs
@@ -8,6 +8,11 @@ namespace FactSet.Protobuf.Stach.Extensions.V2
 {
     public static class StachUtilities
     {
+        /// <summary>
+        /// Returns stringified value for the Protobuf Value object
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>String value</returns>
         public static string ValueToString(Value value)
         {
             switch (value.KindCase)
@@ -34,6 +39,12 @@ namespace FactSet.Protobuf.Stach.Extensions.V2
             }
         }
 
+        /// <summary>
+        /// Returns the actual value object instead of the Protobuf Value object.
+        /// For Lists and Struct, we return the stringified values.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>Actual value object</returns>
         public static object ValueToObject(Value value)
         {
             switch (value.KindCase)


### PR DESCRIPTION
These changes include 2 new methods ConvertToDynamicObject() and ConvertToTransposedDynamicObject(), which are applicable only for the simplified row stach format. 