### PR TITLE
fix(stachutilities) -- Fixing AttributeError for google protobuf timestamp and duration comparison

### DIFF
--- a/python/src/fds/protobuf/stach/extensions/v1/StachUtilities.py
+++ b/python/src/fds/protobuf/stach/extensions/v1/StachUtilities.py
@@ -68,11 +68,11 @@ class StachUtilities:
                 return null_format
             return value
         elif DataType.Name(datatype) == "DURATION":
-            if NullValues.DURATION.equals(value):
+            if NullValues.DURATION == value:
                 return null_format
             return value
         elif DataType.Name(datatype) == "TIMESTAMP":
-            if NullValues.TIMESTAMP.equals(value):
+            if NullValues.TIMESTAMP == value:
                 return null_format
             return value
         else:

--- a/python/src/setup.py
+++ b/python/src/setup.py
@@ -4,7 +4,7 @@ REQUIRES = ["fds.protobuf.stach<2.0.0", "fds.protobuf.stach.v2<2.0.0", "pandas<2
 
 setuptools.setup(
     name="fds.protobuf.stach.extensions",
-    version="1.1.0",
+    version="1.1.1",
     author="Analytics API",
     author_email="analytics.api.support@factset.com",
     description="FactSet stach extensions",


### PR DESCRIPTION
This change changes the null_value_handler() method to use the correct equality check for NullValues.TIMESTAMP and NullValues.DURATION, which do not support the equals() method and must use the "==" operator.