### PR TITLE
Changed versions of dependencies

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -47,7 +47,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <protobuf-version>3.12.2</protobuf-version>
+        <protobuf-version>3.21.4</protobuf-version>
     </properties>
 
     <profiles>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>4.0.1</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Updated versions of dependencies.
1) pkg:maven/org.apache.poi/poi-ooxml@4.0.1 is changed to pkg:maven/org.apache.poi/poi-ooxml@4.1.2
2) pkg:maven/com.google.protobuf/protobuf-java-util@3.12.2 is changed to pkg:maven/com.google.protobuf/protobuf-java-util@3.21.4
3) pkg:maven/com.google.protobuf/protobuf-java@3.12.2 is changed to pkg:maven/com.google.protobuf/protobuf-java@3.21.4