### PR TITLE
fix(java): Updated Vulnerable dependencies

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -154,12 +154,26 @@
             <artifactId>protobuf-java-util</artifactId>
             <version>${protobuf-version}</version>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.factset.protobuf</groupId>-->
+<!--            <artifactId>stach</artifactId>-->
+<!--            <version>1.1.0</version>-->
+<!--        </dependency>-->
         <dependency>
+            <scope>system</scope>
+            <systemPath>C:/Users/jmiriyala02/Downloads/stach-2.0.0.jar</systemPath>
             <groupId>com.factset.protobuf</groupId>
             <artifactId>stach</artifactId>
-            <version>1.1.0</version>
+            <version>2.0.0</version>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.factset.protobuf</groupId>-->
+<!--            <artifactId>stach.v2</artifactId>-->
+<!--            <version>1.0.0</version>-->
+<!--        </dependency>-->
         <dependency>
+            <scope>system</scope>
+            <systemPath>C:/Users/jmiriyala02/Downloads/stach.v2-1.0.0.jar</systemPath>
             <groupId>com.factset.protobuf</groupId>
             <artifactId>stach.v2</artifactId>
             <version>1.0.0</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.factset.protobuf</groupId>
     <artifactId>stachextensions</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
 
     <licenses>
         <license>
@@ -47,7 +47,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <protobuf-version>3.21.8</protobuf-version>
+        <protobuf-version>3.25.5</protobuf-version>
     </properties>
 
     <profiles>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.factset.protobuf</groupId>
     <artifactId>stachextensions</artifactId>
-    <version>1.3.3</version>
+    <version>1.4.0</version>
 
     <licenses>
         <license>
@@ -154,29 +154,15 @@
             <artifactId>protobuf-java-util</artifactId>
             <version>${protobuf-version}</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>com.factset.protobuf</groupId>-->
-<!--            <artifactId>stach</artifactId>-->
-<!--            <version>1.1.0</version>-->
-<!--        </dependency>-->
         <dependency>
-            <scope>system</scope>
-            <systemPath>C:/Users/jmiriyala02/Downloads/stach-2.0.0.jar</systemPath>
             <groupId>com.factset.protobuf</groupId>
             <artifactId>stach</artifactId>
-            <version>2.0.0</version>
+            <version>1.2.0</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>com.factset.protobuf</groupId>-->
-<!--            <artifactId>stach.v2</artifactId>-->
-<!--            <version>1.0.0</version>-->
-<!--        </dependency>-->
         <dependency>
-            <scope>system</scope>
-            <systemPath>C:/Users/jmiriyala02/Downloads/stach.v2-1.0.0.jar</systemPath>
             <groupId>com.factset.protobuf</groupId>
             <artifactId>stach.v2</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Updated the  dependencies for the below packages to their respective version which doesn't have vulnerabilities

com.google.protobuf:protobuf-java ---> 3.21.8 to 3.25.5
com.factset.protobuf:stach ----> 1.1.0 to 1.2.0
com.factset.protobuf:stach.v2 ----> 1.0.0 to 1.1.0

Also bumped the minor version of this **stachextensions** package , latest version after release would be **1.4.0**

All tests has passed:
![image](https://github.com/user-attachments/assets/57e2fb45-c4ce-4753-80b3-b8c9a8026146)
