### PR TITLE
fix(java): Updated java vulnerable dependencies

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Java JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: Build
       run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Java JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 1.8
 
     - name: Build
       run: |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <version>7.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.1</version>
+            <version>7.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.factset.protobuf</groupId>
     <artifactId>stachextensions</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
 
     <licenses>
         <license>
@@ -167,23 +167,33 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.5</version>
+            <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
+            <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20220320</version>
+            <version>20231013</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <version>7.7.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.16</version>
         </dependency>
     </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -182,18 +182,8 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.0</version>
+            <version>7.4.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>2.0.16</version>
         </dependency>
     </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.0</version>
+            <version>7.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.0</version>
+            <version>7.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updated the dependencies for the below packages to their respective version which doesn't have vulnerabilities

com.fasterxml.jackson.core:jackson-core ---> 2.10.5 to 2.13.5
com.fasterxml.jackson.core:jackson-databind ----> 2.10.5.1 to 2.13.5
org.json:json ----> 20220320 to 20231013

Also bumped the minor version of this **stachextensions** package , latest version after release would be **1.5.0**

All tests has passed:
![image](https://github.com/user-attachments/assets/5f7926a0-a500-4a3d-b8bd-246a3bc6c317)

