### PR TITLE
fix(java): Removed poi-ooxml dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.factset.protobuf</groupId>
     <artifactId>stachextensions</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
 
     <licenses>
         <license>
@@ -139,11 +139,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi-ooxml</artifactId>
-            <version>4.1.2</version>
-        </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>

--- a/java/src/main/java/com/factset/protobuf/stach/extensions/v1/StachUtilities.java
+++ b/java/src/main/java/com/factset/protobuf/stach/extensions/v1/StachUtilities.java
@@ -7,8 +7,6 @@ import com.factset.protobuf.stach.table.SeriesDataProto;
 import com.factset.protobuf.stach.table.SeriesDefinitionProto;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
-import org.apache.poi.ss.formula.eval.NotImplementedException;
-
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -70,7 +68,7 @@ public class StachUtilities {
             Timestamp value = seriesData.getTimestampArray().getValues(index);
             return NullValues.TIMESTAMP.equals(value) ? nullFormat : value;
         } else {
-            throw new NotImplementedException(dataType + " is not implemented");
+            throw new UnsupportedOperationException(dataType + " is not implemented");
         }
     }
 }


### PR DESCRIPTION
org.apache.poi:poi-ooxml is just used to take exception class at one place. Replaced that exception class with "UnsupportedOperationException" from java.lang package and removed that dependency.

All test cases passed
![image](https://github.com/user-attachments/assets/955013f2-903a-44cb-b64e-5f7a7e680f25)
