### PR TITLE
fix(python): Updated numpy dependency

### DIFF
--- a/python/src/setup.py
+++ b/python/src/setup.py
@@ -1,10 +1,10 @@
 import setuptools
 
-REQUIRES = ["fds.protobuf.stach<2.0.0", "fds.protobuf.stach.v2<2.0.0", "pandas<3.0.0", "numpy<2.0.0"]
+REQUIRES = ["fds.protobuf.stach<2.0.0", "fds.protobuf.stach.v2<2.0.0", "pandas<3.0.0", "numpy<3.0.0"]
 
 setuptools.setup(
     name="fds.protobuf.stach.extensions",
-    version="1.3.1",
+    version="1.3.2",
     author="Analytics API",
     author_email="analytics.api.support@factset.com",
     description="FactSet stach extensions",

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -5,8 +5,6 @@ fds.protobuf.stach.v2==1.0.2
 isort==5.9.3
 lazy-object-proxy==1.6.0
 mccabe==0.6.1
-numpy==1.21.2
-pandas==1.3.2
 platformdirs==2.3.0
 protobuf==3.16.0
 pylint==2.10.2


### PR DESCRIPTION
1. Updated numpy dependency to be <3.0.0 and increased patch version for Stach Extensions, so that it pickups up the latest version.
2. Removed numpy, pandas dependencies in tests/requirement.txt file as installing Stach Extensions would give these dependencuies