### PR TITLE
chore(release): central-portal

### DIFF
--- a/.github/workflows/release-sdks.yml
+++ b/.github/workflows/release-sdks.yml
@@ -79,23 +79,57 @@ jobs:
       && (github.event.inputs.SDKs == 'java' || github.event.inputs.SDKs == 'all'))
       
     steps:
-    - uses: actions/checkout@v2
-  
-    - name: Set up Java JDK
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+
+    - name: Import GPG key
+      run: |
+        echo "${{ secrets.MAVEN_GPG_PRIVATE_KEY }}" | gpg --batch --import
+        echo 'pinentry-mode loopback' >> ~/.gnupg/gpg.conf
+        
+    - name: Install xmllint
+      run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
+    - name: Extract version from pom.xml
+      id: get_version
+      run: |
+        version=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" auto-generated-sdk/pom.xml)
+        echo "version=$version" >> $GITHUB_OUTPUT
+        if [[ "$version" == *SNAPSHOT* ]]; then
+          echo "is_snapshot=true" >> $GITHUB_OUTPUT
+        else
+          echo "is_snapshot=false" >> $GITHUB_OUTPUT
+        fi
+    - name: Set up JDK for snapshot repository
+      if: steps.get_version.outputs.is_snapshot == 'true'
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
-        server-id: ossrh
-        server-username: MAVEN_USERNAME
-        server-password: MAVEN_PASSWORD
-        gpg-private-key: ${{ env.MAVEN_GPG_PRIVATE_KEY }}
+        java-version: '8'
+        distribution: 'temurin'
+        server-id: central-portal-snapshots
+        server-username: MAVEN_PORTAL_USERNAME
+        server-password: MAVEN_CENTRAL_TOKEN
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
-    
-    - name: Build
-      run: |
-        mvn -B package --file ${{ env.JAVA_SDK_LOCATION }}/pom.xml
-      
+
+    - name: Set up JDK for release repository
+      if: steps.get_version.outputs.is_snapshot == 'false'
+      uses: actions/setup-java@v4
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        server-id: central
+        server-username: MAVEN_PORTAL_USERNAME
+        server-password: MAVEN_CENTRAL_TOKEN
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+    - name: Build with Maven
+      run: mvn -B package --file ${{ env.JAVA_SDK_LOCATION }}/pom.xml
+        
     - name: Publish to Apache Maven Central
-      run: |
-        cd ${{ env.JAVA_SDK_LOCATION }}
-        mvn -Psign-artifacts verify deploy
+      run: cd ${{ env.JAVA_SDK_LOCATION }} && mvn -Psign-artifacts verify deploy
+      env:
+        MAVEN_PORTAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+  

--- a/.github/workflows/release-sdks.yml
+++ b/.github/workflows/release-sdks.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Extract version from pom.xml
       id: get_version
       run: |
-        version=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" auto-generated-sdk/pom.xml)
+        version=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" ${{ env.JAVA_SDK_LOCATION }}/pom.xml)
         echo "version=$version" >> $GITHUB_OUTPUT
         if [[ "$version" == *SNAPSHOT* ]]; then
           echo "is_snapshot=true" >> $GITHUB_OUTPUT

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.factset.protobuf</groupId>
     <artifactId>stachextensions</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -21,10 +21,24 @@
     </licenses>
 
     <distributionManagement>
+        <snapshotRepository>
+            <name>Central Portal Snapshots</name>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <name>Central Repository OSSRH</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>central</id>
+            <name>Central Portal Releases</name>
+            <url>https://central.sonatype.com</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
     </distributionManagement>
 
@@ -100,7 +114,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -118,6 +132,14 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <waitUntil>validated</waitUntil>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -134,6 +156,12 @@
                         <include>**/*Tests.java</include>
                     </includes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <version>0.8.0</version>
+                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -163,7 +163,7 @@
                 <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <deploymentName>${groupId}-${artifactId}-${version}</deploymentName>
+                    <deploymentName>${project.groupId}-${project.artifactId}-${project.version}</deploymentName>
                 </configuration>
             </plugin>
         </plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.factset.protobuf</groupId>
     <artifactId>stachextensions</artifactId>
-    <version>1.6.1-SNAPSHOT</version>
+    <version>1.6.1</version>
 
     <licenses>
         <license>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -162,6 +162,9 @@
                 <groupId>org.sonatype.central</groupId>
                 <version>0.8.0</version>
                 <extensions>true</extensions>
+                <configuration>
+                    <deploymentName>${groupId}-${artifactId}-${version}</deploymentName>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Similar changes as https://github.com/factset/analyticsapi-engines-java-sdk/pull/94
Was able to test both workflows- with and without snapshot versions 
<img width="1686" height="454" alt="image" src="https://github.com/user-attachments/assets/afb04a53-f42a-4a03-a86b-66a63293a624" />
Also updated the code to specify deployment name in both PRs so we don't see the default string 'Deployment'